### PR TITLE
Fix version conflicts caused by PR#316

### DIFF
--- a/privatelib/privatelib.csproj
+++ b/privatelib/privatelib.csproj
@@ -11,10 +11,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="3.3.111.26" />
-      <PackageReference Include="FluentEmail.Core" Version="2.7.0" />
+      <PackageReference Include="AWSSDK.S3" Version="3.7.1.20" />
+      <PackageReference Include="FluentEmail.Core" Version="2.8.0" />
       <PackageReference Include="FluentEmail.Mailgun" Version="2.8.0" />
-      <PackageReference Include="FluentEmail.SendGrid" Version="2.7.0" />
+      <PackageReference Include="FluentEmail.SendGrid" Version="2.8.0" />
       <PackageReference Include="FluentEmail.Smtp" Version="2.7.1" />
       <PackageReference Include="Microsoft.Azure.Storage.Common" Version="11.1.5" />
       <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.5" />

--- a/publicApi/publicApi.csproj
+++ b/publicApi/publicApi.csproj
@@ -56,7 +56,7 @@
       <PackageReference Include="Humanizer" Version="2.8.26" />
       <PackageReference Include="Ical.Net" Version="4.1.11" />
       <PackageReference Include="INIFileParserDotNetCore" Version="2.5.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
       <PackageReference Include="NodaTime" Version="3.0.0" />
       <PackageReference Include="Peachpie.Library" Version="0.9.970" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump AWSSDK.S3 from 3.3.111.26 to 3.7.1.20. [(PR#316)](https://github.com/mindfocus/nextcloud_net/pull/316).
Hope this fix can help you.

Best regards,
sucrose